### PR TITLE
tiff and eps images scales are generated in jpeg format

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,10 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
-- tiff and eps images scales are generated in jpeg format.
-  Fixes, thumbnail view and main view for image contents with tif or eps file.
+- tiff, psd and eps images scales are generated, in jpeg format.
+  Fixes thumbnail view and main view for image contents with tif, psd or eps file.
+  With tif files, scales were generated but couldn't be seen in Plone UI ;
+  psd and eps scales weren't generated.
   Refs https://dev.plone.org/ticket/13077
   [thomasdesvenain]
 

--- a/Products/Archetypes/Field.py
+++ b/Products/Archetypes/Field.py
@@ -2519,7 +2519,7 @@ class ImageField(FileField):
         # PNG compression is OK for RGBA thumbnails
         original_mode = image.mode
         img_format = image.format and image.format or default_format
-        if img_format in ('TIFF', 'EPS'):
+        if img_format in ('TIFF', 'EPS', 'PSD'):
             # non web image format have jpeg thumbnails
             target_format = 'JPEG'
         else:


### PR DESCRIPTION
- tiff and eps images scales are generated in jpeg format.
  Fixes thumbnail view and main view for image contents with tif or eps file.
  Refs https://dev.plone.org/ticket/13077
  [thomasdesvenain]
