### PR TITLE
Calendar popup is now translated.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Load calendar language js related to user preferred language.
+  Calendar popup is now translated. 
+  Refs http://dev.plone.org/ticket/13189
+  [thomasdesvenain]
+
 - tiff, psd and eps images scales are generated, in jpeg format.
   Fixes thumbnail view and main view for image contents with tif, psd or eps file.
   With tif files, scales were generated but couldn't be seen in Plone UI ;

--- a/Products/Archetypes/skins/archetypes/getUniqueWidgetAttr.py
+++ b/Products/Archetypes/skins/archetypes/getUniqueWidgetAttr.py
@@ -1,22 +1,33 @@
 ## Script (Python) "getUniqueWidgetAttr"
-##title=Edit content
 ##bind container=container
 ##bind context=context
 ##bind namespace=
 ##bind script=script
 ##bind subpath=traverse_subpath
 ##parameters=fields, attr
+##title=Edit content
 ##
+from Products.CMFCore.utils import getToolByName
+ltool = getToolByName(context, 'portal_languages', None)
+if ltool:
+    preferred_language = ltool.getPreferredLanguage()
+else:
+    preferred_language = 'en'
 
 order = []
-
 for f in fields:
     widget = f.widget
     helper = getattr(widget, attr, None)
+
     # We expect the attribute value to be a iterable.
     if helper:
-        # I love list comprehension ;)
-        [order.append(item) for item in helper
-         if item not in order]
+        for item in helper:
+            if attr == 'helper_js' and preferred_language != 'en':
+                if item.endswith('-en.js'):
+                    item = item.replace('-en.js', 
+                                        '-%s.js' % preferred_language)
+
+            if item not in order:
+                order.append(item)
 
 return order

--- a/Products/Archetypes/tests/test_widgets.py
+++ b/Products/Archetypes/tests/test_widgets.py
@@ -333,6 +333,12 @@ class WidgetTests(ATSiteTestCase):
         doc = makeContent(self.folder, 'SimpleType', id='doc')
         self.assertEqual(doc.getBestIcon(), 'txt.png')
 
+    def test_helpers(self):
+        self.loginAsPortalOwner()
+        doc = makeContent(self.portal, 'SimpleType', id='doc')
+        fields = [f for f in doc.Schema().values()]
+        self.assertIn('jscalendar/calendar-en.js', 
+                      doc.getUniqueWidgetAttr(fields, 'helper_js'))
 
 def test_suite():
     from unittest import TestSuite, makeSuite


### PR DESCRIPTION
Load calendar language js related to user preferred language.
Calendar popup is now translated.
  Refs http://dev.plone.org/ticket/13189
