### PR TITLE
When displaying a field with a vocabular, get the values and translate them

### DIFF
--- a/Products/Archetypes/browser/utils.py
+++ b/Products/Archetypes/browser/utils.py
@@ -2,6 +2,7 @@ from zope.interface import implements
 from Products.Five import BrowserView
 from Products.Archetypes.interfaces.utils import IUtils
 from zope.i18n import translate
+from zope.i18nmessageid import Message
 
 
 class Utils(BrowserView):
@@ -20,19 +21,19 @@ class Utils(BrowserView):
             return translate(value,
                              domain=domain,
                              context=self.request)
+        _marker = object()
         if value:
             nvalues = []
             for v in value:
                 if not v:
                     continue
-                vocab_value = vocab.getValue(
-                    context.unicodeEncode(v),
-                    context.unicodeEncode(v))
-                # be sure not to have already translated
-                # the text
-                trans_value = _(v)
-                if vocab_value != trans_value:
-                    vocab_value = trans_value
+                v_encoded = context.unicodeEncode(v)
+                vocab_value = vocab.getValue(v_encoded, _marker)
+                # translate explicitly
+                if vocab_value is _marker:
+                    vocab_value = _(v)
+                else:
+                    vocab_value = _(vocab_value)
                 nvalues.append(vocab_value)
             value = ', '.join(nvalues)
         return value

--- a/Products/Archetypes/examples/ComplexType.py
+++ b/Products/Archetypes/examples/ComplexType.py
@@ -1,7 +1,10 @@
+# -*- coding: utf-8 -*-
 from Products.Archetypes import atapi
 from Products.Archetypes import Field
 from SimpleType import SimpleType
 from Products.Archetypes.config import PKG_NAME
+from zope.i18nmessageid import MessageFactory
+
 
 fields = ['StringField',
           'FileField', 'TextField', 'DateTimeField', 'LinesField',
@@ -58,6 +61,10 @@ schema = atapi.Schema(tuple(field_instances) + (
     )) + atapi.ExtensibleMetadata.schema
 
 
+_domain1 = MessageFactory('domain1')
+_domain2 = MessageFactory('domain2')
+
+
 class ComplexType(SimpleType):
     """A simple archetype"""
     schema = SimpleType.schema + schema
@@ -65,10 +72,20 @@ class ComplexType(SimpleType):
     portal_type = 'ComplexType'
 
     def _get_selection_vocab(self):
-        return atapi.DisplayList((('Test', 'Test'), ))
+        return atapi.DisplayList((
+            ('foo', u'Foo'),
+            ('complex', u'C\xf6mpl\xe8x'),
+            ('bar', _domain1(u'Bar')),
+            ('hello', _domain2(u'Hello')),
+            ))
 
     def _get_selection_vocab2(self):
-        return atapi.DisplayList((('Test', 'Test'), ('Test2', 'Test2'), ))
+        return atapi.DisplayList((
+            ('foo2', u'Foo 2'),
+            ('complex2', u'C\xf6mpl\xe8x 2'),
+            ('bar2', _domain1(u'Bar 2')),
+            ('hello2', _domain2(u'Hello 2')),
+            ))
 
 
 atapi.registerType(ComplexType, PKG_NAME)

--- a/Products/Archetypes/tests/test_baseobject.py
+++ b/Products/Archetypes/tests/test_baseobject.py
@@ -89,14 +89,17 @@ class BaseObjectTest(ATSiteTestCase):
         searchable = dummy.SearchableText()
 
         self.assertTrue(isinstance(searchable, basestring))
+        # Note: the vocabulary values used to get translated in some
+        # cases, which during test runs would mean they would get
+        # formatted as '[[plone][some value]]' instead of 'some value'.
         self.assertEquals(searchable,
-            '1 2 Option 1 : printemps [[plone][Option 2 : \xc3\xa9t\xc3\xa9]]')
+            '1 2 Option 1 : printemps Option 2 : \xc3\xa9t\xc3\xa9')
 
         dummy.setMULTIPLEFIELD(['3', '4'])
         searchable = dummy.SearchableText()
 
         self.assertEquals(searchable,
-            '3 4 [[plone][Option 3 : automne]] option3')
+            '3 4 Option 3 : automne option3')
 
     def test_searchableTextUsesIndexMethod(self):
         """See http://dev.plone.org/archetypes/ticket/645

--- a/Products/Archetypes/utils.py
+++ b/Products/Archetypes/utils.py
@@ -575,8 +575,13 @@ class Vocabulary(DisplayList):
             if not msg:
                 return ''
 
-            return translate(msg, self._i18n_domain,
-                             context=self._instance.REQUEST, default=value)
+            # We used to explicitly translate here, but all other code
+            # paths did not return a translation.  So create a Message
+            # that can be translated elsewhere.
+            if not isinstance(msg, basestring):
+                # Possibly a marker object, for example None.  Do not touch it.
+                return msg
+            return Message(msg, domain=self._i18n_domain, default=value)
         else:
             return value
 


### PR DESCRIPTION
This builds on 5daa7af2a1611e23ffdabea3ed9bc51c01b76f17 which is a fix for [ticket 7627](https://dev.plone.org/ticket/7627) but misses some corner cases.  I added tests for those.

The danger is that I now break it for other corner cases. If you know cases where it could fail, please tell me. Bonus points if you can write test cases for those.

@kiorky maybe you can have a look, because you did the original fix.

My branch is based on the 1.9.x branch. Tested in the core-dev 4.3 buildout.
