### PR TITLE
Remove charset=iso-8859-1 for validate html in W3C Validator

### DIFF
--- a/Products/Archetypes/skins/archetypes/base_edit.cpt
+++ b/Products/Archetypes/skins/archetypes/base_edit.cpt
@@ -51,7 +51,6 @@
     <tal:js condition="js"
             repeat="item js">
       <script type="text/javascript"
-              charset="iso-8859-1"
               tal:condition="python:exists('portal/%s' % item)"
               tal:attributes="src string:$portal_url/$item">
       </script>


### PR DESCRIPTION
Message for W3C validator:

"Bad value iso-8859-1 for attribute charset on element script: iso-8859-1 is not a preferred encoding name. The preferred label for this encoding is windows-1252."

No other product plone uses this attribute in javascript calls.
