### PR TITLE
allow brains in vocabularies (used for related Items)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 1.9.4 (unreleased)
 ------------------
 
+- Allow brains (used for related items in an in-and-out-widget)
+  [pbauer]
+
 - Various vocabulary fixes, mostly for translations and
   IntDisplayLists.
   [maurits]
@@ -12,7 +15,7 @@ Changelog
 1.9.4 (2013-08-29)
 ------------------
 
-- Fixed error of validate_content_types when checking a field that was an 
+- Fixed error of validate_content_types when checking a field that was an
   instance of OFS.Image.File
   [ichim-david]
 
@@ -23,7 +26,7 @@ Changelog
 1.9.3 (2013-08-14)
 ------------------
 
-- Avoid UnicodeDecodeError in @@at_utils.translate if the value contains 
+- Avoid UnicodeDecodeError in @@at_utils.translate if the value contains
   special chars
   [gbastien]
 

--- a/Products/Archetypes/utils.py
+++ b/Products/Archetypes/utils.py
@@ -15,6 +15,7 @@ from AccessControl import ModuleSecurityInfo
 from AccessControl.SecurityInfo import ACCESS_PUBLIC
 
 from Acquisition import aq_base, aq_inner, aq_parent
+from Acquisition import ImplicitAcquisitionWrapper
 from ExtensionClass import ExtensionClass
 from App.class_init import InitializeClass
 from Products.CMFCore.utils import getToolByName
@@ -562,8 +563,9 @@ class Vocabulary(DisplayList):
         """
         Get i18n value
         """
-        if not isinstance(key, basestring) and not isinstance(key, int):
-            raise TypeError('DisplayList keys must be strings or ints, got %s' %
+        if (not isinstance(key, basestring) and not isinstance(key, int) and not
+                isinstance(key, ImplicitAcquisitionWrapper)):
+            raise TypeError('DisplayList keys must be strings, ints or brains, got %s' %
                             type(key))
         v = self._keys.get(key, None)
         value = default


### PR DESCRIPTION
Using the in-and-out widget for Relations was no longer possible after the last release. This fixes it.
