### PR TITLE
jq alias is deprecated

### DIFF
--- a/Products/Archetypes/skins/archetypes/widgets/js/textcount.js
+++ b/Products/Archetypes/skins/archetypes/widgets/js/textcount.js
@@ -1,12 +1,12 @@
 <!-- Original:  Ronnie T. Moore -->
 <!-- Dynamic 'fix' by: Nannette Thacker -->
 function textCounter(field, countfield, maxlimit) {
-  var fieldval = jq(field).attr('value');
+  var fieldval = jQuery(field).attr('value');
   if (fieldval.length > maxlimit) {
       // if too long...trim it!
-      jq(field).attr('value',  fieldval.substring(0, maxlimit));
+      jQuery(field).attr('value',  fieldval.substring(0, maxlimit));
       alert( 'This field is limited to ' + maxlimit + ' characters in length.' );
   } 
   // update 'characters left' counter	
-  jq('input[name="' + countfield + '"]').attr('value', Math.max(maxlimit - fieldval.length, 0));
+  jQuery('input[name="' + countfield + '"]').attr('value', Math.max(maxlimit - fieldval.length, 0));
 }


### PR DESCRIPTION
'textCounter' doesn't work in Plone 4.3 because 'jquery-integration.js' is disabled
