### PR TITLE
Improvements to Archetypes integration with structure export/import

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,11 @@ Changelog
 
 - Fix ``MimeTypesRegistry`` test import.
   [thet]
+- Allow read-only fields to be set by the structure importer
+  [MatthewWilkes]
+- Include UID in structure exporter and importer, we can retain
+  references in round-tripped content
+  [MatthewWilkes]
 
 
 1.9.8 (2014-06-03)

--- a/Products/Archetypes/Marshall.py
+++ b/Products/Archetypes/Marshall.py
@@ -277,7 +277,10 @@ class RFC822Marshaller(Marshaller):
         # Include the internal version of IUUID(instance). We're setting this
         # value in the same class, so accessing it directly here saves a
         # Component Registry lookup for every object being exported
-        headers.append(('UID', getattr(aq_base(instance), UUID_ATTR, None)))
+        if hasattr(aq_base(instance), UUID_ATTR):
+            # Non-referencable content isn't exportable by default, but we should
+            # shouldn't include the uuid if it's not there.
+            headers.append(('UID', getattr(aq_base(instance), UUID_ATTR, None)))
         
         for field in fields:
             if field.type in ('file', 'image', 'object'):

--- a/Products/Archetypes/Marshall.py
+++ b/Products/Archetypes/Marshall.py
@@ -10,6 +10,7 @@ from AccessControl import ClassSecurityInfo
 from Acquisition import aq_base
 from App.class_init import InitializeClass
 from OFS.Image import File
+from Products.Archetypes.config import UUID_ATTR
 from Products.Archetypes.Field import TextField, FileField
 from Products.Archetypes.interfaces.marshall import IMarshall
 from Products.Archetypes.interfaces.layer import ILayer
@@ -234,6 +235,13 @@ class RFC822Marshaller(Marshaller):
                 mutator = field.getMutator(instance)
                 if mutator is not None:
                     mutator(v)
+            if k == 'UID':
+                # Set the UID if it's provided. Generally you don't
+                # care about a UID, but having it be settable allows
+                # other import steps to reference the object, such
+                # as portlets or collection criteria
+                setattr(aq_base(instance), UUID_ATTR, v)
+            
         content_type = headers.get('Content-Type')
         if not kwargs.get('mimetype', None):
             kwargs.update({'mimetype': content_type})
@@ -261,6 +269,12 @@ class RFC822Marshaller(Marshaller):
         headers = []
         fields = [f for f in instance.Schema().fields()
                   if f.getName() != pname]
+        
+        # Include the internal version of IUUID(instance). We're setting this
+        # value in the same class, so accessing it directly here saves a
+        # Component Registry lookup for every object being exported
+        headers.append(('UID', getattr(aq_base(instance), UUID_ATTR, None)))
+        
         for field in fields:
             if field.type in ('file', 'image', 'object'):
                 continue

--- a/Products/Archetypes/Marshall.py
+++ b/Products/Archetypes/Marshall.py
@@ -228,13 +228,17 @@ class RFC822Marshaller(Marshaller):
             del kwargs['file']
         headers, body = parseRFC822(data)
         for k, v in headers.items():
+            if k == 'id':
+                # Never change the id, it needs to happen as part of
+                # a rename
+                continue
             if v.strip() == 'None':
                 v = None
             field = instance.getField(k)
             if field is not None:
-                mutator = field.getMutator(instance)
-                if mutator is not None:
-                    mutator(v)
+                # Don't indirect through the mutator, to enable
+                # us to populate fields that are normally read only
+                field.set(instance, v)
             if k == 'UID':
                 # Set the UID if it's provided. Generally you don't
                 # care about a UID, but having it be settable allows


### PR DESCRIPTION
These changes allow additional fields to be round-tripped in the structure importer when dealing with AT content. They are useful for using the structure importer for creating initial state of applications, as it's likely there will be `mode='r'` fields that need an initial value populating.