### PR TITLE
compare picklist entry value not text

### DIFF
--- a/Products/Archetypes/skins/archetypes/widgets/js/picklist.js
+++ b/Products/Archetypes/skins/archetypes/widgets/js/picklist.js
@@ -8,7 +8,7 @@ function pick_selectAllWords(theList) {
 function pick_addNewKeyword(toList,newText,newValue) {
   theToList=document.getElementById(toList);
   for (var x=0; x < theToList.length; x++) {
-    if (theToList[x].text == newText) {
+    if (theToList[x].value == newValue) {
       return false;
     }
   }


### PR DESCRIPTION
I ran into a situation where the available options in a picklist had the same names but different values. Once the first one was selected, I couldn't select another entry with the same name because the `text` property was being compared instead of the `value` property.