### PR TITLE
Update base_edit.cpt

### DIFF
--- a/Products/Archetypes/skins/archetypes/base_edit.cpt
+++ b/Products/Archetypes/skins/archetypes/base_edit.cpt
@@ -67,7 +67,7 @@
       <style type="text/css"
              media="all"
              tal:condition="python:exists('portal/%s' % item)"
-             tal:content="structure string:&lt;!-- @import url($portal_url/$item); --&gt;">
+             tal:content="structure string:@import url($portal_url/$item);">
       </style>
     </tal:css>
     <tal:block define="macro edit_macros/css | nothing"


### PR DESCRIPTION
Removed comments from CSS @import.

After applying the "Plone Hotfix 20151006" update, it looks like the CSS for the third-party jscalendar product was not being imported, so the calendar pop-up was unstyled.

It appears that the way 'structure' was handling the HTML comment changed in this patch.

In looking at how portal_css presents its imports, those are not commented out, so I figure not including the HTML comments around the @import url(...) statement is not an issue.

I don't recall off the top of my head which browser that was meant to appease, but based on:

http://www.w3.org/Style/LieBos2e/enter/Overview.en.html#browsers

it was probably Netscape 1 and Internet Explorer 2.