### PR TITLE
No longer try to mock plone.app.widgets in tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New:
 
 Fixes:
 
-- *add item here*
+- No longer try to mock plone.app.widgets in tests.  [maurits]
 
 
 1.10.13 (2016-02-25)

--- a/Products/Archetypes/tests/test_pawidgets.py
+++ b/Products/Archetypes/tests/test_pawidgets.py
@@ -320,38 +320,37 @@ class RelatedItemsWidgetTests(unittest.TestCase):
         class ExampleContent(object):
             implements(IAttributeUUID)
 
-        with mock.patch('plone.app.widgets.utils.getUtility') as mock_method:
-            obj1 = ExampleContent()
-            obj2 = ExampleContent()
-            notify(ObjectCreatedEvent(obj1))
-            notify(ObjectCreatedEvent(obj2))
+        obj1 = ExampleContent()
+        obj2 = ExampleContent()
+        notify(ObjectCreatedEvent(obj1))
+        notify(ObjectCreatedEvent(obj2))
 
-            self.field.getName.return_value = 'fieldname'
-            self.field.getAccessor.return_value = lambda: [obj1, obj2]
-            self.field.multiValued = True
+        self.field.getName.return_value = 'fieldname'
+        self.field.getAccessor.return_value = lambda: [obj1, obj2]
+        self.field.multiValued = True
 
-            widget = RelatedItemsWidget()
+        widget = RelatedItemsWidget()
 
-            self.assertEqual(
-                {
-                    'name': 'fieldname',
-                    'value': '{};{}'.format(IUUID(obj1), IUUID(obj2)),
-                    'pattern': 'relateditems',
-                    'pattern_options': {
-                        'folderTypes': ['Folder'],
-                        'homeText': u'Home',
-                        'searchAllText': u'Entire site',
-                        'searchText': u'Search',
-                        'separator': ';',
-                        'orderable': True,
-                        'maximumSelectionSize': -1,
-                        'vocabularyUrl': '/@@getVocabulary?name='
-                                         'plone.app.vocabularies.Catalog'
-                                         '&field=fieldname',
-                    },
+        self.assertEqual(
+            {
+                'name': 'fieldname',
+                'value': '{};{}'.format(IUUID(obj1), IUUID(obj2)),
+                'pattern': 'relateditems',
+                'pattern_options': {
+                    'folderTypes': ['Folder'],
+                    'homeText': u'Home',
+                    'searchAllText': u'Entire site',
+                    'searchText': u'Search',
+                    'separator': ';',
+                    'orderable': True,
+                    'maximumSelectionSize': -1,
+                    'vocabularyUrl': '/@@getVocabulary?name='
+                                     'plone.app.vocabularies.Catalog'
+                                     '&field=fieldname',
                 },
-                widget._base_args(self.context, self.field, self.request),
-            )
+            },
+            widget._base_args(self.context, self.field, self.request),
+        )
 
     def test_single_value(self):
         from zope.event import notify
@@ -371,29 +370,28 @@ class RelatedItemsWidgetTests(unittest.TestCase):
         self.field.getAccessor.return_value = lambda: obj1
         self.field.multiValued = False
 
-        with mock.patch('plone.app.widgets.utils.getUtility') as mock_method:
-            widget = RelatedItemsWidget()
+        widget = RelatedItemsWidget()
 
-            self.assertEqual(
-                {
-                    'name': 'fieldname',
-                    'value': '{}'.format(IUUID(obj1)),
-                    'pattern': 'relateditems',
-                    'pattern_options': {
-                        'folderTypes': ['Folder'],
-                        'homeText': u'Home',
-                        'separator': ';',
-                        'orderable': True,
-                        'searchAllText': u'Entire site',
-                        'searchText': u'Search',
-                        'maximumSelectionSize': 1,
-                        'vocabularyUrl': '/@@getVocabulary?name='
-                                         'plone.app.vocabularies.Catalog'
-                                         '&field=fieldname',
-                    },
+        self.assertEqual(
+            {
+                'name': 'fieldname',
+                'value': '{}'.format(IUUID(obj1)),
+                'pattern': 'relateditems',
+                'pattern_options': {
+                    'folderTypes': ['Folder'],
+                    'homeText': u'Home',
+                    'separator': ';',
+                    'orderable': True,
+                    'searchAllText': u'Entire site',
+                    'searchText': u'Search',
+                    'maximumSelectionSize': 1,
+                    'vocabularyUrl': '/@@getVocabulary?name='
+                                     'plone.app.vocabularies.Catalog'
+                                     '&field=fieldname',
                 },
-                widget._base_args(self.context, self.field, self.request),
-            )
+            },
+            widget._base_args(self.context, self.field, self.request),
+        )
 
     def test_single_valued_empty(self):
         from Products.Archetypes.Widget import RelatedItemsWidget
@@ -402,29 +400,28 @@ class RelatedItemsWidgetTests(unittest.TestCase):
         self.field.getAccessor.return_value = lambda: None
         self.field.multiValued = False
 
-        with mock.patch('plone.app.widgets.utils.getUtility') as mock_method:
-            widget = RelatedItemsWidget()
+        widget = RelatedItemsWidget()
 
-            self.assertEqual(
-                {
-                    'name': 'fieldname',
-                    'value': '',
-                    'pattern': 'relateditems',
-                    'pattern_options': {
-                        'folderTypes': ['Folder'],
-                        'homeText': u'Home',
-                        'separator': ';',
-                        'orderable': True,
-                        'searchAllText': u'Entire site',
-                        'searchText': u'Search',
-                        'maximumSelectionSize': 1,
-                        'vocabularyUrl': '/@@getVocabulary?name='
-                                         'plone.app.vocabularies.Catalog'
-                                         '&field=fieldname',
-                    },
+        self.assertEqual(
+            {
+                'name': 'fieldname',
+                'value': '',
+                'pattern': 'relateditems',
+                'pattern_options': {
+                    'folderTypes': ['Folder'],
+                    'homeText': u'Home',
+                    'separator': ';',
+                    'orderable': True,
+                    'searchAllText': u'Entire site',
+                    'searchText': u'Search',
+                    'maximumSelectionSize': 1,
+                    'vocabularyUrl': '/@@getVocabulary?name='
+                                     'plone.app.vocabularies.Catalog'
+                                     '&field=fieldname',
                 },
-                widget._base_args(self.context, self.field, self.request),
-            )
+            },
+            widget._base_args(self.context, self.field, self.request),
+        )
 
     def test_multiple_widgets(self):
         from zope.event import notify
@@ -442,67 +439,66 @@ class RelatedItemsWidgetTests(unittest.TestCase):
         notify(ObjectCreatedEvent(obj1))
         notify(ObjectCreatedEvent(obj2))
 
-        with mock.patch('plone.app.widgets.utils.getUtility') as mock_method:
-            self.context.fieldvalue = lambda: obj1
+        self.context.fieldvalue = lambda: obj1
 
-            field1 = ReferenceField(
-                'fieldname1',
-                relationship="A",
-                multiValued=False,
-                widget=RelatedItemsWidget(),
-            )
-            field1.accessor = "fieldvalue"
+        field1 = ReferenceField(
+            'fieldname1',
+            relationship="A",
+            multiValued=False,
+            widget=RelatedItemsWidget(),
+        )
+        field1.accessor = "fieldvalue"
 
-            self.assertEqual(
-                {
-                    'name': 'fieldname1',
-                    'value': '{}'.format(IUUID(obj1)),
-                    'pattern': 'relateditems',
-                    'pattern_options': {
-                        'folderTypes': ['Folder'],
-                        'homeText': u'Home',
-                        'separator': ';',
-                        'orderable': True,
-                        'searchAllText': u'Entire site',
-                        'searchText': u'Search',
-                        'maximumSelectionSize': 1,
-                        'vocabularyUrl': '/@@getVocabulary?name='
-                                         'plone.app.vocabularies.Catalog'
-                                         '&field=fieldname1',
-                    },
+        self.assertEqual(
+            {
+                'name': 'fieldname1',
+                'value': '{}'.format(IUUID(obj1)),
+                'pattern': 'relateditems',
+                'pattern_options': {
+                    'folderTypes': ['Folder'],
+                    'homeText': u'Home',
+                    'separator': ';',
+                    'orderable': True,
+                    'searchAllText': u'Entire site',
+                    'searchText': u'Search',
+                    'maximumSelectionSize': 1,
+                    'vocabularyUrl': '/@@getVocabulary?name='
+                                     'plone.app.vocabularies.Catalog'
+                                     '&field=fieldname1',
                 },
-                field1.widget._base_args(self.context, field1, self.request),
-            )
+            },
+            field1.widget._base_args(self.context, field1, self.request),
+        )
 
-            field2 = ReferenceField(
-                'fieldname2',
-                relationship="A",
-                multiValued=True,
-                widget=RelatedItemsWidget(),
-            )
-            field2.accessor = "fieldvalue"
-            self.context.fieldvalue = lambda: [obj1, obj2]
+        field2 = ReferenceField(
+            'fieldname2',
+            relationship="A",
+            multiValued=True,
+            widget=RelatedItemsWidget(),
+        )
+        field2.accessor = "fieldvalue"
+        self.context.fieldvalue = lambda: [obj1, obj2]
 
-            self.assertEqual(
-                {
-                    'name': 'fieldname2',
-                    'value': '{};{}'.format(IUUID(obj1), IUUID(obj2)),
-                    'pattern': 'relateditems',
-                    'pattern_options': {
-                        'folderTypes': ['Folder'],
-                        'homeText': u'Home',
-                        'separator': ';',
-                        'orderable': True,
-                        'searchAllText': u'Entire site',
-                        'searchText': u'Search',
-                        'maximumSelectionSize': -1,
-                        'vocabularyUrl': '/@@getVocabulary?name='
-                                         'plone.app.vocabularies.Catalog'
-                                         '&field=fieldname2',
-                    },
+        self.assertEqual(
+            {
+                'name': 'fieldname2',
+                'value': '{};{}'.format(IUUID(obj1), IUUID(obj2)),
+                'pattern': 'relateditems',
+                'pattern_options': {
+                    'folderTypes': ['Folder'],
+                    'homeText': u'Home',
+                    'separator': ';',
+                    'orderable': True,
+                    'searchAllText': u'Entire site',
+                    'searchText': u'Search',
+                    'maximumSelectionSize': -1,
+                    'vocabularyUrl': '/@@getVocabulary?name='
+                                     'plone.app.vocabularies.Catalog'
+                                     '&field=fieldname2',
                 },
-                field2.widget._base_args(self.context, field2, self.request),
-            )
+            },
+            field2.widget._base_args(self.context, field2, self.request),
+        )
 
 
 class QueryStringWidgetTests(unittest.TestCase):

--- a/Products/Archetypes/tests/test_pawidgets.py
+++ b/Products/Archetypes/tests/test_pawidgets.py
@@ -303,7 +303,9 @@ class RelatedItemsWidgetTests(unittest.TestCase):
     def setUp(self):
 
         self.request = TestRequest(environ={'HTTP_ACCEPT_LANGUAGE': 'en'})
-        self.context = Mock(absolute_url=lambda: '')
+        self.context = Mock(
+            absolute_url=lambda: '',
+            getPhysicalPath=lambda: ('', 'Plone', 'doc'))
         self.field = Mock()
 
         xmlconfig.file('configure.zcml', plone.uuid,
@@ -347,6 +349,12 @@ class RelatedItemsWidgetTests(unittest.TestCase):
                     'vocabularyUrl': '/@@getVocabulary?name='
                                      'plone.app.vocabularies.Catalog'
                                      '&field=fieldname',
+                    'basePath': '/Plone/doc',
+                    'rootPath': '/',
+                    'sort_on': 'sortable_title',
+                    'sort_order': 'ascending',
+                    'treeVocabularyUrl': '/@@getVocabulary?name='
+                                         'plone.app.vocabularies.Catalog',
                 },
             },
             widget._base_args(self.context, self.field, self.request),
@@ -388,6 +396,12 @@ class RelatedItemsWidgetTests(unittest.TestCase):
                     'vocabularyUrl': '/@@getVocabulary?name='
                                      'plone.app.vocabularies.Catalog'
                                      '&field=fieldname',
+                    'basePath': '/Plone/doc',
+                    'rootPath': '/',
+                    'sort_on': 'sortable_title',
+                    'sort_order': 'ascending',
+                    'treeVocabularyUrl': '/@@getVocabulary?name='
+                                         'plone.app.vocabularies.Catalog',
                 },
             },
             widget._base_args(self.context, self.field, self.request),
@@ -418,6 +432,12 @@ class RelatedItemsWidgetTests(unittest.TestCase):
                     'vocabularyUrl': '/@@getVocabulary?name='
                                      'plone.app.vocabularies.Catalog'
                                      '&field=fieldname',
+                    'basePath': '/Plone/doc',
+                    'rootPath': '/',
+                    'sort_on': 'sortable_title',
+                    'sort_order': 'ascending',
+                    'treeVocabularyUrl': '/@@getVocabulary?name='
+                                         'plone.app.vocabularies.Catalog',
                 },
             },
             widget._base_args(self.context, self.field, self.request),
@@ -465,6 +485,12 @@ class RelatedItemsWidgetTests(unittest.TestCase):
                     'vocabularyUrl': '/@@getVocabulary?name='
                                      'plone.app.vocabularies.Catalog'
                                      '&field=fieldname1',
+                    'basePath': '/Plone/doc',
+                    'rootPath': '/',
+                    'sort_on': 'sortable_title',
+                    'sort_order': 'ascending',
+                    'treeVocabularyUrl': '/@@getVocabulary?name='
+                                         'plone.app.vocabularies.Catalog',
                 },
             },
             field1.widget._base_args(self.context, field1, self.request),
@@ -495,6 +521,12 @@ class RelatedItemsWidgetTests(unittest.TestCase):
                     'vocabularyUrl': '/@@getVocabulary?name='
                                      'plone.app.vocabularies.Catalog'
                                      '&field=fieldname2',
+                    'basePath': '/Plone/doc',
+                    'rootPath': '/',
+                    'sort_on': 'sortable_title',
+                    'sort_order': 'ascending',
+                    'treeVocabularyUrl': '/@@getVocabulary?name='
+                                         'plone.app.vocabularies.Catalog',
                 },
             },
             field2.widget._base_args(self.context, field2, self.request),


### PR DESCRIPTION
We were mocking plone.app.widgets.utils.getUtility,but this was nowhere used.
I see I cleaned up the usage of it myself a few months ago.
Current plone.app.widgets.utils has no getUtility anymore.

But: I have got no idea why I got the following failures on master locally while Jenkins is happy:

```
Error in test test_multi_valued (
  Products.Archetypes.tests.test_pawidgets.RelatedItemsWidgetTests)
Traceback (most recent call last):
  File "/Users/maurits/shared-eggs/unittest2-0.5.1-py2.7.egg/unittest2/case.py", line 340,
 in run testMethod()
  File ".../5.0/src/Products.Archetypes/Products/Archetypes/tests/test_pawidgets.py", 
line 323, in test_multi_valued
    with mock.patch('plone.app.widgets.utils.getUtility') as mock_method:
  File "/Users/maurits/shared-eggs/mock-1.0.1-py2.7.egg/mock.py", line 1268, in __enter__
    original, local = self.get_original()
  File "/Users/maurits/shared-eggs/mock-1.0.1-py2.7.egg/mock.py", line 1242, in get_original
    "%s does not have the attribute %r" % (target, name)
AttributeError: <module 'plone.app.widgets.utils' from 
'.../5.0/src/plone.app.widgets/plone/app/widgets/utils.pyc'>
does not have the attribute 'getUtility'
```

The AttributeError is absolutely correct: plone.app.widgets/utils.py has no getUtility. And since it mentions `utils.pyc`: no I don't have a somehow outdated `.pyc` file lying around.

The tests for this pull request should fail, because they are missing another commit that I have locally. But I first want to see them fail.

Ah: the above error is when I do `bin/test -s Products.Archetypes -m test_pawidgets`.
With `bin/alltests-at` the tests pass.
What is the difference in setup between those two???
A pdb in test_pawidgets.py is ignored when doing `bin/alltests-at`. What is going on?