### PR TITLE
DateWidget, DatetimeWidget (pick-a-date) now able to clear previous

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- DateWidget, DatetimeWidget now able to clear previous values.
+  [seanupton]
+
 - Use zope.interface decorator.
   [gforcada]
 

--- a/Products/Archetypes/Widget.py
+++ b/Products/Archetypes/Widget.py
@@ -1023,6 +1023,10 @@ class DateWidget(BasePatternWidget):
 
         value = value.split('-')
 
+        if value[0] == '':
+            # empty value, clear any previous value
+            return None, {}
+
         try:
             value = DateTime(datetime(*map(int, value)))
         except:
@@ -1102,8 +1106,11 @@ class DatetimeWidget(DateWidget):
             return empty_marker
 
         tmp = value.split(' ')
+
         if not tmp[0]:
-            return empty_marker
+            # empty: clear, not preserve, any previous value
+            return None, {}
+
         value = tmp[0].split('-')
         if len(tmp) == 2 and ':' in tmp[1]:
             value += tmp[1].split(':')

--- a/Products/Archetypes/tests/test_pawidgets.py
+++ b/Products/Archetypes/tests/test_pawidgets.py
@@ -124,6 +124,16 @@ class DateWidgetTests(unittest.TestCase):
             (datetime(2011, 11, 22))
         )
 
+    def test_process_form_empty_existing(self):
+        form = {
+            'fieldname': ''
+        }
+        self.assertEqual(
+            self.widget.process_form(
+                self.context, self.field, form)[0],
+            None
+        )
+
 
 class DatetimeWidgetTests(unittest.TestCase):
 
@@ -186,6 +196,16 @@ class DatetimeWidgetTests(unittest.TestCase):
             self.widget.process_form(
                 self.context, self.field, form)[0].asdatetime(),
             (datetime(2011, 11, 22, 13, 30))
+        )
+
+    def test_process_form_empty_existing(self):
+        form = {
+            'fieldname': ''
+        }
+        self.assertEqual(
+            self.widget.process_form(
+                self.context, self.field, form)[0],
+            None
         )
 
 


### PR DESCRIPTION
values; fixes inability to clear an already set date or datetime in Archetypes fields.