### PR TITLE
Fix Plone 4 Archetypes edit forms to use autotoc pattern markup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,11 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Support Autotoc pattern, if plone.app.widgets 1.x is installed, such
+  that form tabbing is enabled using this pattern.  Markup change
+  is consistent with how plone.app.z3cform 1.0.x templates specify
+  pattern use and configuration in edit forms/fieldsets.
+  [seanupton]
 
 Bug fixes:
 

--- a/Products/Archetypes/skins/archetypes/edit_macros.pt
+++ b/Products/Archetypes/skins/archetypes/edit_macros.pt
@@ -80,11 +80,12 @@
             method="post"
             enctype="multipart/form-data"
             class="enableUnloadProtection enableAutoFocus atBaseEditForm"
+            data-pat-autotoc="levels: legend; section: fieldset; className: autotabs"
             action=""
             id=""
             tal:attributes="action python:context.absolute_url()+'/'+template.id;
                             id string:${portal_type}-base-edit;
-                            class python:test(path('allow_tabbing|nothing'), 'enableUnloadProtection enableAutoFocus enableFormTabbing enableUnlockProtection', 'enableUnloadProtection enableAutoFocus enableUnlockProtection');">
+                            class python:test(path('allow_tabbing|nothing'), 'enableUnloadProtection enableAutoFocus enableFormTabbing enableUnlockProtection pat-autotoc', 'enableUnloadProtection enableAutoFocus enableUnlockProtection');">
           <metal:block define-slot="extra_top" />
 
           <div tal:replace="structure provider:archetypes.edit.beforefieldsets" />


### PR DESCRIPTION
...fixing form tabs on siteswith plone.app.widgets 1.x installed.