### PR TITLE
no allowable_content_types for description (avoid validation)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- no allowable_content_types for description (avoid validation)
+  [tschorr]
+
 - *add item here*
 
 

--- a/Products/Archetypes/ExtensibleMetadata.py
+++ b/Products/Archetypes/ExtensibleMetadata.py
@@ -91,7 +91,6 @@ class ExtensibleMetadata(Persistence.Persistent):
             searchable=1,
             accessor="Description",
             default_content_type='text/plain',
-            allowable_content_types=('text/plain',),
             widget=TextAreaWidget(
                 label=_(u'label_description', default=u'Description'),
                 description=_(u'help_description',


### PR DESCRIPTION
`Product.Archetypes.Field.validate` invokes `validate_content_types` if `allowable_content_types` is set on a field. In case of the description field, this can lead to surprising validation results because the method is trying to guess the content type using the `mimetypes_registry`. Example: If you enter the word 'Stammdaten' (german for master data) as the first word into a description field, you see a validation error telling you that the MIME type 'video/quicktime' is not allowed for the field. This is because the `mimetypes_registry` is trying to guess the MIME type of the string 'Stammdaten' using a test in `Products.MimetypesRegistry.mime_types.magic`. The term 'Stammdaten' matches the following test pattern:

[4, 'string', '=', 'mdat', 'video/quicktime']

(letters 'mdat' starting at position4)

It is perfectly valid to have 'Stammdaten' as the first term in a german description, but Plone doesn't let you save this. Looking at the other test patterns there are potentially many more cases like this.

The testing procedure maybe could be improved (validating the content type is not about guessing the MIME type from the content but rather testing wether the content conforms to one of the allowable content types) but the suggestion is to simply drop the constraint on the description field since text/plain is the fallback.
