### PR TITLE
Don't use document/folder_icon.gif in the test profile.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,10 +14,10 @@ New features:
 
 Bug fixes:
 
+- Don't use document/folder_icon.gif in the test profile.  Use png instead.  [maurits]
+
 - no allowable_content_types for description (avoid validation)
   [tschorr]
-
-- *add item here*
 
 
 1.11.2 (2016-09-14)

--- a/Products/Archetypes/profiles/sample_types/types/ATBIFolder.xml
+++ b/Products/Archetypes/profiles/sample_types/types/ATBIFolder.xml
@@ -4,7 +4,7 @@
  <property name="title">ATBIFolder</property>
  <property
     name="description">A simple folder that uses AllowedTypesByIfaceMixin</property>
- <property name="content_icon">folder_icon.gif</property>
+ <property name="content_icon">folder_icon.png</property>
  <property name="content_meta_type">ATBIFolder</property>
  <property name="product">Archetypes</property>
  <property name="factory">addATBIFolder</property>

--- a/Products/Archetypes/profiles/sample_types/types/ComplexType.xml
+++ b/Products/Archetypes/profiles/sample_types/types/ComplexType.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title">ComplexType</property>
  <property name="description">A simple archetype</property>
- <property name="content_icon">document_icon.gif</property>
+ <property name="content_icon">document_icon.png</property>
  <property name="content_meta_type">ComplexType</property>
  <property name="product">Archetypes</property>
  <property name="factory">addComplexType</property>

--- a/Products/Archetypes/profiles/sample_types/types/DDocument.xml
+++ b/Products/Archetypes/profiles/sample_types/types/DDocument.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title">Demo Doc</property>
  <property name="description">An extensible Document (test) type</property>
- <property name="content_icon">document_icon.gif</property>
+ <property name="content_icon">document_icon.png</property>
  <property name="content_meta_type">DDocument</property>
  <property name="product">Archetypes</property>
  <property name="factory">addDDocument</property>

--- a/Products/Archetypes/profiles/sample_types/types/Fact.xml
+++ b/Products/Archetypes/profiles/sample_types/types/Fact.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title">Fact</property>
  <property name="description">A quoteable fact or tidbit</property>
- <property name="content_icon">document_icon.gif</property>
+ <property name="content_icon">document_icon.png</property>
  <property name="content_meta_type">Fact</property>
  <property name="product">Archetypes</property>
  <property name="factory">addFact</property>

--- a/Products/Archetypes/profiles/sample_types/types/MySimpleType.xml
+++ b/Products/Archetypes/profiles/sample_types/types/MySimpleType.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title">My Simple Type</property>
  <property name="description">A simple archetype</property>
- <property name="content_icon">document_icon.gif</property>
+ <property name="content_icon">document_icon.png</property>
  <property name="content_meta_type">SimpleType</property>
  <property name="product">Archetypes</property>
  <property name="factory">addSimpleType</property>

--- a/Products/Archetypes/profiles/sample_types/types/Refnode.xml
+++ b/Products/Archetypes/profiles/sample_types/types/Refnode.xml
@@ -4,7 +4,7 @@
  <property name="title">Refnode</property>
  <property
     name="description">A simple archetype for testing references. It can point to itself</property>
- <property name="content_icon">document_icon.gif</property>
+ <property name="content_icon">document_icon.png</property>
  <property name="content_meta_type">Refnode</property>
  <property name="product">Archetypes</property>
  <property name="factory">addRefnode</property>

--- a/Products/Archetypes/profiles/sample_types/types/SimpleBTreeFolder.xml
+++ b/Products/Archetypes/profiles/sample_types/types/SimpleBTreeFolder.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title">Simple BTree Folder</property>
  <property name="description">A simple folderish archetype</property>
- <property name="content_icon">folder_icon.gif</property>
+ <property name="content_icon">folder_icon.png</property>
  <property name="content_meta_type">SimpleBTreeFolder</property>
  <property name="product">Archetypes</property>
  <property name="factory">addSimpleBTreeFolder</property>

--- a/Products/Archetypes/profiles/sample_types/types/SimpleFile.xml
+++ b/Products/Archetypes/profiles/sample_types/types/SimpleFile.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title">Simple File Type</property>
  <property name="description">An File (test) type</property>
- <property name="content_icon">document_icon.gif</property>
+ <property name="content_icon">document_icon.png</property>
  <property name="content_meta_type">SimpleFile</property>
  <property name="product">Archetypes</property>
  <property name="factory">addSimpleFile</property>

--- a/Products/Archetypes/profiles/sample_types/types/SimpleFolder.xml
+++ b/Products/Archetypes/profiles/sample_types/types/SimpleFolder.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title">Simple Folder</property>
  <property name="description">A simple folderish archetype</property>
- <property name="content_icon">folder_icon.gif</property>
+ <property name="content_icon">folder_icon.png</property>
  <property name="content_meta_type">SimpleFolder</property>
  <property name="product">Archetypes</property>
  <property name="factory">addSimpleFolder</property>

--- a/Products/Archetypes/profiles/sample_types/types/SimpleProtectedType.xml
+++ b/Products/Archetypes/profiles/sample_types/types/SimpleProtectedType.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title">SimpleProtectedType</property>
  <property name="description">A simple archetype</property>
- <property name="content_icon">document_icon.gif</property>
+ <property name="content_icon">document_icon.png</property>
  <property name="content_meta_type">SimpleProtectedType</property>
  <property name="product">Archetypes</property>
  <property name="factory">addSimpleProtectedType</property>

--- a/Products/Archetypes/profiles/sample_types/types/SimpleType.xml
+++ b/Products/Archetypes/profiles/sample_types/types/SimpleType.xml
@@ -3,7 +3,7 @@
    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
  <property name="title">Simple Type</property>
  <property name="description">A simple archetype</property>
- <property name="content_icon">document_icon.gif</property>
+ <property name="content_icon">document_icon.png</property>
  <property name="content_meta_type">SimpleType</property>
  <property name="product">Archetypes</property>
  <property name="factory">addSimpleType</property>


### PR DESCRIPTION
Use png instead.

We could change the document_icon and folder_icon in `ArchetypeTool.registerClasses` and `BaseFolder.content_icon` too, but the first one is already not called anywhere in Plone 4.3, and content_icons should be done in the GS profile.  Or in css actually.