### PR TITLE
Make AnnotationStorage awareness of OFS.HistoryAware optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- ``OFS.HistoryAware`` was dropped in Zope 4.
+  Make AnnotationStorage awareness of it optional.
+  [jensens]
 
 Bug fixes:
 


### PR DESCRIPTION
 since it was dropped in Zope4