### PR TITLE
Default display value of a Vocabulary i18n-message must be unicode.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Bug fixes:
 - Fix tests to work with latest plone.app.widgets 2.1.
   [thet]
 
+- Default display value of a ``Vocabulary`` i18n-message must be unicode, enforce.
+  Needed to work with latest zope.i18nmessageid 4.0.3 release (and later).
+  [jensens]
 
 1.12 (2016-12-06)
 -----------------

--- a/Products/Archetypes/utils.py
+++ b/Products/Archetypes/utils.py
@@ -598,6 +598,8 @@ class Vocabulary(DisplayList):
             # that can be translated elsewhere.
             if not isinstance(msg, unicode):
                 msg = msg.decode('utf-8')
+            if not isinstance(value, unicode):
+                value = value.decode('utf-8')
             return Message(msg, domain=self._i18n_domain, default=value)
         else:
             return value


### PR DESCRIPTION
Needed to work with latest zope.i18nmessageid 4.0.3 release (and later).