### PR TITLE
Use $ instead of jq in textcount.js. [Plone 4.3]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Use ``$`` instead of ``jq`` in ``textcount.js``.
+  This is for example used by PloneFormGen when you set a
+  maximum character count for a text field.  [maurits]
 
 
 1.9.13 (2016-10-03)

--- a/Products/Archetypes/skins/archetypes/widgets/js/textcount.js
+++ b/Products/Archetypes/skins/archetypes/widgets/js/textcount.js
@@ -1,12 +1,12 @@
 <!-- Original:  Ronnie T. Moore -->
 <!-- Dynamic 'fix' by: Nannette Thacker -->
 function textCounter(field, countfield, maxlimit) {
-  var fieldval = jq(field).attr('value');
+  var fieldval = $(field).attr('value');
   if (fieldval.length > maxlimit) {
       // if too long...trim it!
-      jq(field).attr('value',  fieldval.substring(0, maxlimit));
+      $(field).attr('value',  fieldval.substring(0, maxlimit));
       alert( 'This field is limited to ' + maxlimit + ' characters in length.' );
-  } 
-  // update 'characters left' counter	
-  jq('input[name="' + countfield + '"]').attr('value', Math.max(maxlimit - fieldval.length, 0));
+  }
+  // update 'characters left' counter
+  $('input[name="' + countfield + '"]').attr('value', Math.max(maxlimit - fieldval.length, 0));
 }


### PR DESCRIPTION
This is for example used by PloneFormGen when you set a maximum character count for a text field.

This is the last javascript file in Archetypes that still used the old `jq` variable.