### PR TITLE
Fix bug with Widget's postback attribute [Plone 4.3]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New features:
 Bug fixes:
 
 - Fix bug with Widget's postback attribute, that prevented fields from
-being populated with the submitted empty value in the case of an error.
+  being populated with the submitted empty value in the case of an error.
   [pgrunewald]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix bug with Widget's postback attribute, that prevented fields from
+being populated with the submitted empty value in the case of an error.
+  [pgrunewald]
 
 
 1.9.14 (2017-04-08)
@@ -34,8 +36,6 @@ Bug fixes:
 
 - no allowable_content_types for description (avoid validation)
   [tschorr]
-
-- *add item here*
 
 
 1.9.12 (2016-08-12)

--- a/Products/Archetypes/skins/archetypes/widgets/field.pt
+++ b/Products/Archetypes/skins/archetypes/widgets/field.pt
@@ -67,7 +67,7 @@
                     edit_accessor python:field.getEditAccessor(here);
                     getMethod python:(widget.populate and (edit_accessor or accessor)) or None;
                     value python:getMethod and getMethod();
-                    value python:widget.postback and request.get(fieldName, value) or value;
+                    value python:request.get(fieldName, value) if widget.postback else value;
                     portal python:context.portal_url.getPortalObject();
                     visCondition python:field.widget.testCondition(context.aq_inner.getParentNode(), portal, context);
                     error_id python:errors.get(fieldName)">


### PR DESCRIPTION
There is a problem with the current implementation in the `1.9.x` branch with the postback attribute.

**Steps to reproduce:**

1. Save an object with two populated fields.
2. Edit this object, make the first one empty and now edit the second in a way, an error message is triggered.

**Expected result:**

The first field should **stay** empty, since this new value has been explicitly been submitted. Also the error happened in a different field.

**Observed result:**

The first field is populated with the original value.

The problem lies in the following line:

```python
value = widget.postback and request.get(fieldName, value) or value
```

Just as reminder from the docs what postback actually does:
> Common Widget Attributes 
postback -  If this is enabled, then when an error is raised, the field is repopulated; for fields such as a password field, this shouldn't be the case. Usually this is True by default.