### PR TITLE
Fix bug with Widget's postback attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix bugs with Widget's postback attribute, that prevented fields from
+  being populated with the submitted empty value in the case of an error.
+  [pgrunewald]
 
 
 1.14.0 (2017-04-01)

--- a/Products/Archetypes/skins/archetypes/widgets/field.pt
+++ b/Products/Archetypes/skins/archetypes/widgets/field.pt
@@ -67,8 +67,7 @@
                     edit_accessor python:field.getEditAccessor(here);
                     getMethod python:(widget.populate and (edit_accessor or accessor)) or None;
                     value python:getMethod and getMethod();
-                    value python:widget.postback and request.get(fieldName, value);
-                    value python:value == '' and (getMethod and getMethod()) or value;
+                    value python:request.get(fieldName, value) if widget.postback else value;
                     portal python:context.portal_url.getPortalObject();
                     visCondition python:field.widget.testCondition(context.aq_inner.getParentNode(), portal, context);
                     error_id python:errors.get(fieldName)">


### PR DESCRIPTION
This PR is identical to https://github.com/plone/Products.Archetypes/pull/80, but applies for the master branch.

It also fixes a problem, that was only present here: When widget.postback is set to False for a string field, then it is populated with "False" as string value. I looked up, why the implementation differed and it was said to ensure, that boolean fields are correctly populated with their default values. I checked that too in my local setup and it works like expected.