### PR TITLE
Prevent AttributeError on deleting a Reference 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Prevent AttributeError on deleting a Reference from a object that is gone.
+  Fixes https://github.com/plone/plone.app.contenttypes/issues/41
+  [pbauer]
 
 
 1.14.1 (2017-06-16)

--- a/Products/Archetypes/ReferenceEngine.py
+++ b/Products/Archetypes/ReferenceEngine.py
@@ -555,6 +555,8 @@ class ReferenceCatalog(UniqueObject, UIDResolver, ZCatalog):
     def _deleteReference(self, referenceObject):
         try:
             sobj = referenceObject.getSourceObject()
+            if sobj is None:
+                return
             referenceObject.delHook(self, sobj,
                                     referenceObject.getTargetObject())
         except ReferenceException:


### PR DESCRIPTION
... from a object that is gone.

Fixes https://github.com/plone/plone.app.contenttypes/issues/41