### PR TITLE
Fix bugs with old jquery version and textlimit alert

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,12 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed textcount.js support jquery>1.6.
+  [vkarppinen]
+
+- Fixed a bug (that it was possible to enter text length over maxlimit)
+  by replacing maxlimit alert() with highlighting textcountfield.
+  [vkarppinen]
 
 
 1.14.1 (2017-06-16)

--- a/Products/Archetypes/skins/archetypes/widgets/js/textcount.js
+++ b/Products/Archetypes/skins/archetypes/widgets/js/textcount.js
@@ -1,13 +1,15 @@
-<!-- Original:  Ronnie T. Moore -->
-<!-- Dynamic 'fix' by: Nannette Thacker -->
+// Original:  Ronnie T. Moore
+// Dynamic 'fix' by: Nannette Thacker
 function textCounter(field, countfield, maxlimit) {
   var fieldval = jQuery(field).val();
-  var countfield = jQuery('input[name="' + countfield + '"]');
+  var counterElem = jQuery('input[name="' + countfield + '"]');
   if (fieldval.length > maxlimit) {
-      // if too long...trim it!
-      jQuery(field).val(fieldval.substring(0, maxlimit));
-      countfield.css('border', '1px solid red');
+    // if too long...trim it!
+    jQuery(field).val(fieldval.substring(0, maxlimit));
+    counterElem.css('border-color', 'red');
+  } else {
+    counterElem.css('border-color', '#ccc');
   }
   // update 'characters left' counter
-  countfield.attr('value', Math.max(maxlimit - fieldval.length, 0));
+  counterElem.val(Math.max(maxlimit - fieldval.length, 0));
 }

--- a/Products/Archetypes/skins/archetypes/widgets/js/textcount.js
+++ b/Products/Archetypes/skins/archetypes/widgets/js/textcount.js
@@ -1,12 +1,13 @@
 <!-- Original:  Ronnie T. Moore -->
 <!-- Dynamic 'fix' by: Nannette Thacker -->
 function textCounter(field, countfield, maxlimit) {
-  var fieldval = jQuery(field).attr('value');
+  var fieldval = jQuery(field).val();
+  var countfield = jQuery('input[name="' + countfield + '"]');
   if (fieldval.length > maxlimit) {
       // if too long...trim it!
-      jQuery(field).attr('value',  fieldval.substring(0, maxlimit));
-      alert( 'This field is limited to ' + maxlimit + ' characters in length.' );
-  } 
-  // update 'characters left' counter	
-  jQuery('input[name="' + countfield + '"]').attr('value', Math.max(maxlimit - fieldval.length, 0));
+      jQuery(field).val(fieldval.substring(0, maxlimit));
+      countfield.css('border', '1px solid red');
+  }
+  // update 'characters left' counter
+  countfield.attr('value', Math.max(maxlimit - fieldval.length, 0));
 }


### PR DESCRIPTION
- Fixed textcount.js support jquery>1.6.
- Fixed a bug (that it was possible to enter text length over maxlimit) by replacing maxlimit alert() with highlighting textcountfield.[vkarppinen]