### PR TITLE
Fix non-callable accessor when accessor is not defined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Bug fixes:
   Fixes https://github.com/plone/plone.app.contenttypes/issues/41
   [pbauer]
 
+- Make Field::getAccessor() fallback value to be callable as expected
+  [zemm]
 
 1.14.1 (2017-06-16)
 -------------------

--- a/Products/Archetypes/Field.py
+++ b/Products/Archetypes/Field.py
@@ -700,8 +700,8 @@ class Field(DefaultLayerContainer):
         """Return the accessor method for getting data out of this
         field"""
         if self.accessor:
-            return getattr(instance, self.accessor, None)
-        return None
+            return getattr(instance, self.accessor, lambda: None)
+        return lambda: None
 
     security.declarePublic('getEditAccessor')
 
@@ -710,8 +710,8 @@ class Field(DefaultLayerContainer):
         field e.g.: for editing
         """
         if self.edit_accessor:
-            return getattr(instance, self.edit_accessor, None)
-        return None
+            return getattr(instance, self.edit_accessor, lambda: None)
+        return lambda: None
 
     security.declarePublic('getMutator')
 


### PR DESCRIPTION
I was looking at a broken `RichTextField` on `Products.PloneFormGen` (smcmahon/Products.PloneFormGen#173)
and the (one of the) problem(s) seemed to be a field with an accessor that was `None`.
Instead of fixing the specific case, I looked at `Archetype`'s
implemention of `Field::getAccessor()`, and noticed that

a) It's documented as _"Return the accessor method ..."_
b) If accessor is not set, it defaults to None - which is not
   a method as advertised
c) `getAccessor()` is used only via happy-path everywhere at
   `Products.Archetypes1 like so: `field.getAccessor(context)()`

I thought the most propriate fix would be to make the fallback
safe by returning a function evaluating to `None`.

## Waiting for input

I'm not familiar with Plone, so I'll wait an input on whether something could potentially depend on this seemingly broken implementation, and wether this should be marked as a bugfix or breaking change, if accepted at all?
