### PR TITLE
Update Field::getAccessor() doc to reflect fallback behavior

### DIFF
--- a/Products/Archetypes/Field.py
+++ b/Products/Archetypes/Field.py
@@ -698,7 +698,7 @@ class Field(DefaultLayerContainer):
 
     def getAccessor(self, instance):
         """Return the accessor method for getting data out of this
-        field"""
+        field, or None if the field has no accessor"""
         if self.accessor:
             return getattr(instance, self.accessor, None)
         return None


### PR DESCRIPTION
Old method doc hinted that it was safe to call getAccessor return value, as is done in many places (`field.getAccessor(context)()`). Discussed in #94.