### PR TITLE
Fix a issue trying to add a existing column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix a issue trying to add a existing column when reinstalling
+  plone.app.mulitlingual in Plone 5.1
+  [pbauer]
 
 
 1.14.2 (2017-08-27)

--- a/Products/Archetypes/exportimport/catalog.py
+++ b/Products/Archetypes/exportimport/catalog.py
@@ -3,6 +3,9 @@ from Products.GenericSetup.utils import exportObjects
 from Products.GenericSetup.utils import importObjects
 from Products.GenericSetup.ZCatalog.exportimport import ZCatalogXMLAdapter
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 def importCatalogTool(context, name='portal_catalog'):
     """Import catalog.
@@ -61,7 +64,10 @@ class CatalogXMLAdapter(ZCatalogXMLAdapter):
                     self.context.delColumn(col)
                 continue
             if col not in self.context.schema()[:]:
-                self.context.addColumn(col)
+                try:
+                    self.context.addColumn(col)
+                except Exception as e:
+                    logger.info(e)
                 # If we added a new column we need to update the
                 # metadata even if this will take a while
                 self.context.refreshCatalog()


### PR DESCRIPTION
I had the issue with the reference_catalog when reinstalling plone.app.mulitlingual in Plone 5.1:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module Products.PDBDebugMode.runcall, line 70, in pdb_runcall
  Module ZPublisher.Publish, line 48, in call_object
  Module <string>, line 6, in reinstallProducts
  Module AccessControl.requestmethod, line 70, in _curried
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 784, in reinstallProducts
  Module <string>, line 3, in installProducts
  Module AccessControl.requestmethod, line 70, in _curried
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 686, in installProducts
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 602, in installProduct
   - __traceback_info__: ('plone.app.multilingual',)
  Module Products.GenericSetup.tool, line 388, in runAllImportStepsFromProfile
   - __traceback_info__: profile-plone.app.multilingual:default
  Module Products.GenericSetup.tool, line 1433, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1245, in _doRunImportStep
   - __traceback_info__: reference_catalog
  Module Products.Archetypes.exportimport.reference, line 14, in importCatalogTool
  Module Products.Archetypes.exportimport.catalog, line 13, in importCatalogTool
  Module Products.GenericSetup.utils, line 849, in importObjects
   - __traceback_info__: reference_catalog
  Module Products.GenericSetup.utils, line 512, in _importBody
  Module Products.GenericSetup.ZCatalog.exportimport, line 69, in _importNode
  Module Products.Archetypes.exportimport.catalog, line 64, in _initColumns
  Module Products.ZCatalog.ZCatalog, line 885, in addColumn
  Module Products.ZCatalog.Catalog, line 195, in addColumn
  Module Products.ZCatalog.ProgressHandler, line 52, in report
TypeError: unsupported operand type(s) for %: 'int' and 'NoneType'
```