### PR TITLE
Remove condition which leads to selected=selected on every option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Bug fixes:
 - Test fixes for changes in plone.app.widgets querystring options.
   [thet]
 
+- Remove superfluous expression in select widget which leads to 
+  selected=selected attribute on all options if certain conditions are met.
+  [dhavlik]
+
 1.14.2 (2017-08-27)
 -------------------
 

--- a/Products/Archetypes/skins/archetypes/widgets/selection.pt
+++ b/Products/Archetypes/skins/archetypes/widgets/selection.pt
@@ -108,7 +108,7 @@
 
                         <option tal:repeat="item vocab"
                                 tal:attributes="value item;
-                                                selected python:item in selection and 'selected' or (not selection and not value and 'selected') or  None"
+                                                selected python:item in selection and 'selected' or  None"
                                 tal:content="python:vocab.getValue(item)"
                                 i18n:translate=""
                                 />


### PR DESCRIPTION
If you have a select widget with no default value, and there is not yet a selected value, the widget is rendered with selected="selected" on every option. This does not feel right, and browsers are selecting the last element from the list then.

The condition I removed was introduced while fixing #13716 (https://web.archive.org/web/20131022024713/https://dev.plone.org/ticket/13716). I don't think that this was the correct place to fix that. Also, there were some changes to ReferenceField since the fix, and I wasn't able to reproduce the behaviour described there (with or without my change).

With ongoing Plone 5 development, Archetypes is no longer used for Plone content. But PloneFormGen still relies on it.

It also cannot be worked around easily, because templates in subdirectories of FSDirectoryViews in portal_skins are not customisable. 