### PR TITLE
Have @@kss_field_decorator_view return itself when called.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,13 @@ Bug fixes:
 - Test fixes for changes in plone.app.widgets querystring options.
   [thet]
 
+- Have @@kss_field_decorator_view return itself when called.
+  In Zope 4 BrowserViews need to either implement a __call__ method or have a template.
+  Using context/@@kss_field_decorator_view in templates would raise
+  "AttributeError: __call__" since the view is called by chameleon.
+  [pbauer]
+
+
 1.14.2 (2017-08-27)
 -------------------
 

--- a/Products/Archetypes/browser/fields.py
+++ b/Products/Archetypes/browser/fields.py
@@ -6,6 +6,8 @@ class DefaultFieldDecoratorView(BrowserView):
     meanwhile, allow it to be used from the templates if
     kss is not loaded.
     '''
+    def __call__(self):
+        return self
 
     def getKssUIDClass(self):
         return ''

--- a/Products/Archetypes/skins/archetypes/edit_macros.pt
+++ b/Products/Archetypes/skins/archetypes/edit_macros.pt
@@ -49,13 +49,13 @@
 
       <div id="archetypes-schemata-links"
            tal:condition="python: fieldsets and not allow_tabbing">
-        <tal:block repeat="set fieldsets">
-          <tal:current condition="python:set == fieldset and fieldsets != ['default']">
-            <strong>[<span tal:content="set" i18n:translate="" />]</strong>
+        <tal:block repeat="fset fieldsets">
+          <tal:current condition="python:fset == fieldset and fieldsets != ['default']">
+            <strong>[<span tal:content="fset" i18n:translate="" />]</strong>
           </tal:current>
-          <tal:others condition="python:set != fieldset">
-            <a href="#" tal:attributes="href string:${context/absolute_url}/${template/getId}?fieldset=${set}">
-            [<span tal:content="set" i18n:translate="" />]</a>
+          <tal:others condition="python:fset != fieldset">
+            <a href="#" tal:attributes="href string:${context/absolute_url}/${template/getId}?fieldset=${fset}">
+            [<span tal:content="fset" i18n:translate="" />]</a>
           </tal:others>
         </tal:block>
       </div>


### PR DESCRIPTION
In Zope 4 BrowserViews need to either implement a ``__call__`` method or have a template.
Using context/@@kss_field_decorator_view in templates would raise
``AttributeError: __call__`` since the view is called by chameleon but has no call-method.

This is maybe a bug in PageTemplates in Zope4 or a issue in many AT-templates. These templates (and the view) will be removed for Plone 6 anyway...