### PR TITLE
Prevent AttributeError on deleting a Reference

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- Prevent AttributeError on deleting a Reference from a object that is
+  gone. Backport from master #91. Fixes plone/plone.app.contenttypes#41.
+  [fredvd, pbauer]
 
 1.9.18 (2018-05-03)
 -------------------

--- a/Products/Archetypes/ReferenceEngine.py
+++ b/Products/Archetypes/ReferenceEngine.py
@@ -557,6 +557,8 @@ class ReferenceCatalog(UniqueObject, UIDResolver, ZCatalog):
     def _deleteReference(self, referenceObject):
         try:
             sobj = referenceObject.getSourceObject()
+            if sobj is None:
+                return
             referenceObject.delHook(self, sobj,
                                     referenceObject.getTargetObject())
         except ReferenceException:


### PR DESCRIPTION
 from object that is gone.
Backport from master #91. Fixes plone/plone.app.contenttypes#41.