### PR TITLE
Made the bbb_at imports conditional.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ New features:
 Bug fixes:
 
 - Switch to new TestCase using AT after PloneTestcase is now DX.
-  [pbauer]
+  Fall back to the old TestCase in case of an older plone.app.testing.
+  [pbauer, maurits]
 
 
 1.15.3 (2018-06-18)

--- a/Products/Archetypes/tests/attestcase.py
+++ b/Products/Archetypes/tests/attestcase.py
@@ -1,4 +1,8 @@
-from plone.app.testing import bbb_at
+try:
+    from plone.app.testing import bbb_at
+except ImportError:
+    # plone.app.testing 5 or earlier
+    from plone.app.testing import bbb as bbb_at
 from plone.app.testing import FunctionalTesting, applyProfile
 from Products.GenericSetup import EXTENSION, profile_registry
 

--- a/Products/Archetypes/tests/test_date_components_support_script.py
+++ b/Products/Archetypes/tests/test_date_components_support_script.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from plone.app.testing.bbb_at import PloneTestCase
+try:
+    from plone.app.testing.bbb_at import PloneTestCase
+except ImportError:
+    # plone.app.testing 5 or earlier
+    from plone.app.testing.bbb import PloneTestCase
 
 from DateTime import DateTime
 

--- a/Products/Archetypes/tests/test_interfaces.py
+++ b/Products/Archetypes/tests/test_interfaces.py
@@ -48,7 +48,11 @@ from Products.Archetypes.Storage import Storage, ReadOnlyStorage, \
     StorageLayer, AttributeStorage, ObjectManagedStorage, MetadataStorage
 from Products.Archetypes.atapi import registerType
 
-from plone.app.testing.bbb_at import PTC_FUNCTIONAL_TESTING
+try:
+    from plone.app.testing.bbb_at import PTC_FUNCTIONAL_TESTING
+except ImportError:
+    # plone.app.testing 5 or earlier
+    from plone.app.testing.bbb import PTC_FUNCTIONAL_TESTING
 
 
 def className(klass):


### PR DESCRIPTION
Fall back to plone.app.testing.bbb, needed in plone.app.testing 5 or earlier.
Fixes problem reported in https://github.com/plone/Products.Archetypes/pull/111#issuecomment-425200126
