### PR TITLE
Move generateUniqueId skin script from Products.CMFPlone to Archetypes

### DIFF
--- a/Products/Archetypes/skins/archetypes/generateUniqueId.py
+++ b/Products/Archetypes/skins/archetypes/generateUniqueId.py
@@ -1,0 +1,23 @@
+## Script (Python) "generateUniqueId"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind subpath=traverse_subpath
+##parameters=type_name=None
+##title=
+
+from DateTime import DateTime
+from random import random
+
+now = DateTime()
+time = '%s.%s' % (now.strftime('%Y-%m-%d'), str(now.millis())[7:])
+rand = str(random())[2:6]
+prefix = ''
+suffix = ''
+
+if type_name is not None:
+    prefix = type_name.replace(' ', '_') + '.'
+prefix = prefix.lower()
+
+return prefix + time + rand + suffix

--- a/news/114.feature
+++ b/news/114.feature
@@ -1,0 +1,2 @@
+Move generateUniqueId script from CMFPlone here. 
+It has no use outside Archetypes world.


### PR DESCRIPTION
replaces #115, see https://github.com/plone/Products.CMFPlone/pull/2564#issuecomment-432296649