### PR TITLE
Make QueryStringWidgetTests more robust/independent of implementation details

### DIFF
--- a/Products/Archetypes/tests/test_pawidgets.py
+++ b/Products/Archetypes/tests/test_pawidgets.py
@@ -599,23 +599,16 @@ class QueryStringWidgetTests(unittest.TestCase):
         ]
 
         widget = QueryStringWidget()
-
-        self.assertEqual(
+        base_args = widget._base_args(self.context, self.field, self.request)
+        self.assertDictContainsSubset(
             {
                 'name': 'fieldname',
                 'value': '[{"query": "string1"}, {"query": "string2"}]',
                 'pattern': 'querystring',
-                'pattern_options': {
-                    'indexOptionsUrl': '/@@qsOptions',
-                    'previewCountURL': '/@@querybuildernumberofresults',
-                    'previewURL': '/@@querybuilder_html_results',
-                    'patternAjaxSelectOptions': None,
-                    'patternDateOptions': None,
-                    'patternRelateditemsOptions': None,
-                },
             },
-            widget._base_args(self.context, self.field, self.request),
+            base_args,
         )
+        self.assertIn('pattern_options', base_args.keys())
 
 
 class TinyMCEWidgetTests(unittest.TestCase):

--- a/news/124.bugfix
+++ b/news/124.bugfix
@@ -1,0 +1,4 @@
+Problem: refactoring plone.app.widgets is not easy with too detailed expectations on the output of the pattern_options.
+Its also outside the scope of this test.
+Solution: check if there are pattern_options, but now what they are exactly.
+[jensens]


### PR DESCRIPTION
Problem: refactoring plone.app.widgets is not easy with too detailed expectations on the output of the pattern_options. Its also outside the scope of this test.

Solution: check if there are pattern_options, but now what they are exactly.