### PR TITLE
Fixed UnicodeEncodeError when editing Archetypes rich text.

### DIFF
--- a/Products/Archetypes/Widget.py
+++ b/Products/Archetypes/Widget.py
@@ -1470,7 +1470,7 @@ class TinyMCEWidget(BasePatternWidget):
                 mt_select.append(opt)
 
             # Render the combined widget
-            rendered = '{}\n{}'.format(
+            rendered = u'{}\n{}'.format(
                 textarea_widget.render(),
                 etree.tostring(mt_select)
             )

--- a/news/2832.bugfix
+++ b/news/2832.bugfix
@@ -1,0 +1,1 @@
+Fixed ``UnicodeEncodeError`` when editing Archetypes rich text.  [maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2832