### PR TITLE
Lifted the ceiling for maximum date 2020 to 2050 in all places

### DIFF
--- a/Products/Archetypes/skins/archetypes/date_components_support.py
+++ b/Products/Archetypes/skins/archetypes/date_components_support.py
@@ -25,7 +25,7 @@ now = DateTime()
 # from CMFPlone.DublinCore
 CEILING = DateTime(9999, 0)
 FLOOR = DateTime(1970, 0)
-PLONE_CEILING = DateTime(2021, 0)  # 2020-12-31
+PLONE_CEILING = DateTime(2051, 0)  # 2050-12-31
 
 
 def month_names():

--- a/news/133.bugfix
+++ b/news/133.bugfix
@@ -1,0 +1,3 @@
+Lifted the ceiling for the maximum date from end of 2020 to 2051 in all places.
+See `issue 133 <https://github.com/plone/Products.Archetypes/issues/133>`_.
+[maurits]


### PR DESCRIPTION
See https://github.com/plone/Products.Archetypes/issues/133
We missed a spot in commit cf5d40b414b6339fa3a2a49e2d18dad8767de11c.

Jenkins started [failing since the new year](https://jenkins.plone.org/job/plone-5.2-python-2.7/1204/testReport/junit/Products.Archetypes.tests.test_date_components_support_script/TestDateComponentsSupportDefault/testYears/):

```
{'selected': 1, 'id': 2020, 'value': 2020} != {'selected': None, 'id': 2020, 'value': 2020}
- {'id': 2020, 'selected': 1, 'value': 2020}
?                          ^

+ {'id': 2020, 'selected': None, 'value': 2020}
?                          ^^^^


  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/jenkins/.buildout/eggs/cp27m/Products.Archetypes-1.16.3-py2.7.egg/Products/Archetypes/tests/test_date_components_support_script.py", line 207, in testYears
    self.assertEqual(years[i], data[i])
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 836, in assertDictEqual
    self.fail(self._formatMessage(msg, standardMsg))
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 410, in fail
    raise self.failureException(msg)
```