### PR TITLE
Fixed incompatibility with zope.component 5.

### DIFF
--- a/Products/Archetypes/event.py
+++ b/Products/Archetypes/event.py
@@ -3,7 +3,7 @@
 
 from zope.interface import implementer
 
-from zope.component.interfaces import ObjectEvent
+from zope.interface.interfaces import ObjectEvent
 from zope.lifecycleevent import ObjectModifiedEvent
 
 from Products.Archetypes.interfaces import IObjectInitializedEvent

--- a/Products/Archetypes/interfaces/event.py
+++ b/Products/Archetypes/interfaces/event.py
@@ -1,7 +1,7 @@
 """Event-related interfaces
 """
 
-from zope.component.interfaces import IObjectEvent
+from zope.interface.interfaces import IObjectEvent
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 # Modification

--- a/Products/Archetypes/mimetype_utils.py
+++ b/Products/Archetypes/mimetype_utils.py
@@ -6,7 +6,7 @@ try:
     from Products.CMFPlone.interfaces import IMarkupSchema
     from plone.registry.interfaces import IRegistry
     from zope.component import getUtility
-    from zope.component.interfaces import ComponentLookupError
+    from zope.interface.interfaces import ComponentLookupError
 except ImportError:
     IMarkupSchema = None
 

--- a/Products/Archetypes/tests/events.txt
+++ b/Products/Archetypes/tests/events.txt
@@ -9,7 +9,7 @@ that listens for object events for `IBaseObject`:
   >>> from StringIO import StringIO
   >>> from Products.Archetypes.tests.utils import makeContent, aputrequest
   >>> from Products.Archetypes.interfaces import IBaseObject
-  >>> from zope.component.interfaces import IObjectEvent
+  >>> from zope.interface.interfaces import IObjectEvent
 
   >>> class Handler:
   ...     def __init__(self):

--- a/news/462.bugfix
+++ b/news/462.bugfix
@@ -1,0 +1,3 @@
+Fixed incompatibility with ``zope.component`` 5.
+``zope.component.interfaces`` has long been a backwards compatibility import for ``zope.interface.interfaces``, but not anymore.
+[maurits]


### PR DESCRIPTION
`zope.component.interfaces` has long been a backwards compatibility import for `zope.interface.interfaces`, but not anymore.
See the [660 failures](https://jenkins.plone.org/job/pull-request-5.2-2.7/2060/) on Jenkins 5.2-2.7 for PR https://github.com/plone/buildout.coredev/pull/725.

We need this change, to be able to use Zope 4.6.2 in Plone 5.2, unless we decide to keep the old zope.component 4.
This change works in both cases.
