### PR TITLE
Prevent installation on Python 3, where we know Archetypes does not work

### DIFF
--- a/news/3330.bugfix
+++ b/news/3330.bugfix
@@ -1,0 +1,2 @@
+Prevent installation on Python 3, as we know Archetypes does not work there.
+[maurits]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,5 @@ ignore =
     bootstrap.py
 
 [bdist_wheel]
-universal = 1
-
-[zest.releaser]
-create-wheel = yes
+# Py2 only
+universal = 0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,12 @@
 from setuptools import setup, find_packages
 
+import sys
+
+
+if sys.version_info[0] != 2:
+    # Prevent creating or installing a distribution with Python 3.
+    raise ValueError("Archetypes is Python 2 only.")
+
 version = '1.16.6.dev0'
 
 setup(name='Products.Archetypes',
@@ -28,6 +35,7 @@ setup(name='Products.Archetypes',
       namespace_packages=['Products'],
       include_package_data=True,
       zip_safe=False,
+      python_requires="==2.7.*",
       extras_require=dict(
         test=[
             'zope.annotation',


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/issues/3330

Only needs to be tested on Jenkins on Py 2, because Archetypes is not included in the Python 3 eggs, so this PR will have no effect.